### PR TITLE
Slightly clearer English for cooldowns

### DIFF
--- a/src/classes/Command.js
+++ b/src/classes/Command.js
@@ -16,7 +16,7 @@ class Command extends Toggle {
     
     this.settings = {
       cooldown: options.cooldown || 1000,
-      cooldownmsg: options.cooldownmsg || "You're using this command too frequently! Please wait {time} before using it again. Voters only have half of all cooldowns.",
+      cooldownmsg: options.cooldownmsg || "You're using this command too frequently! Please wait {time} before using it again. Voters have their cooldown times cut in half.",
       errorMessage: null,
       disableMessage: null,
       lowerCaseArgs: typeof options.lowerCaseArgs === "number" ? [options.lowerCaseArgs] : options.lowerCaseArgs || false,


### PR DESCRIPTION
I doubt you even expected a pull request, but I might as well.

Currently, the default cooldown message is:
`"You're using this command too frequently! Please wait {time} before using it again. Voters only have half of all cooldowns."`

Most of this message is fine, but the final part of the message, `Voters only have half of all cooldowns.`, seems rather unclear (it took me a bit to understand what it was trying to say). This pull request attempts to fix that by changing it to `Voters have their cooldown times cut in half.`, which is a bit clearer in my opinion.

There might be a better way of wording it, IDK. English is complex.